### PR TITLE
Fixes issues #2 and #3. Update of Makefile.am and packet-sensorlab.c

### DIFF
--- a/plugin/sensorlab/Makefile.am
+++ b/plugin/sensorlab/Makefile.am
@@ -1,7 +1,4 @@
 # Makefile.am
-# Automake file for sensorlab plugin
-# By Steve Limkemann <stevelim@dgtech.com>
-# Copyright 1998 Steve Limkemann
 #
 # Wireshark - Network traffic analyzer
 # By Gerald Combs <gerald@wireshark.org>
@@ -20,11 +17,27 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-#
 
-include Makefile.common
 include $(top_srcdir)/Makefile.am.inc
 include ../Makefile.am.inc
+
+# the name of the plugin
+PLUGIN_NAME = sensorlab
+
+# Non-generated sources to be scanned for registration routines
+NONGENERATED_REGISTER_C_FILES = \
+	packet-sensorlab.c
+
+# Non-generated sources
+NONGENERATED_C_FILES = \
+	$(NONGENERATED_REGISTER_C_FILES)
+
+# Headers.
+CLEAN_HEADER_FILES = \
+	packet-sensorlab.h
+
+HEADER_FILES = \
+	$(CLEAN_HEADER_FILES)
 
 plugin_LTLIBRARIES = sensorlab.la
 
@@ -49,8 +62,5 @@ MAINTAINERCLEANFILES = \
 	plugin.c
 
 EXTRA_DIST = \
-	Makefile.common		\
-	Makefile.nmake		\
-	moduleinfo.nmake	\
 	plugin.rc.in		\
 	CMakeLists.txt

--- a/plugin/sensorlab/packet-sensorlab.c
+++ b/plugin/sensorlab/packet-sensorlab.c
@@ -997,7 +997,7 @@ display_frame_produce(packet_info* pinfo, sensorlab_frame_info_s* info, gchar* f
 
 	frame_dissector =find_dissector(frame_dissector_name);
 	if(frame_dissector && info->payload.frame_info.data_length >0){
-		payload_tvb = tvb_new_subset(tvb, FRAME_PRODUCE_DATA_FIELD,  info->payload.frame_info.data_length, -1);
+		payload_tvb = tvb_new_subset_length(tvb, FRAME_PRODUCE_DATA_FIELD,  info->payload.frame_info.data_length);
 		frame_tree = proto_item_add_subtree(frame_item, ett_frame);
 		call_dissector(frame_dissector, payload_tvb, pinfo, frame_tree);
 	}
@@ -1037,7 +1037,7 @@ display_frame_data_update(packet_info* pinfo, sensorlab_frame_info_s* info, gcha
 
 	frame_dissector =find_dissector(frame_dissector_name);
 	if(frame_dissector && info->payload.frame_info.data_length >0){
-		payload_tvb = tvb_new_subset(tvb, FRAME_DATA_UPDATE_DATA_FIELD,  info->payload.frame_info.data_length, -1);
+		payload_tvb = tvb_new_subset_length(tvb, FRAME_DATA_UPDATE_DATA_FIELD,  info->payload.frame_info.data_length);
 		frame_tree = proto_item_add_subtree(frame_item, ett_frame);
 		call_dissector(frame_dissector, payload_tvb, pinfo, frame_tree);
 	}
@@ -1132,7 +1132,7 @@ display_frame_tx(packet_info* pinfo, sensorlab_frame_info_s* info, gchar* frame_
 
 	frame_dissector =find_dissector(frame_dissector_name);
 	if(frame_dissector && info->payload.frame_info.data_length >0){
-		payload_tvb = tvb_new_subset(tvb, FRAME_TX_DATA_FIELD,  info->payload.frame_info.data_length, -1);
+		payload_tvb = tvb_new_subset_length(tvb, FRAME_TX_DATA_FIELD,  info->payload.frame_info.data_length);
 		frame_tree = proto_item_add_subtree(frame_item, ett_frame);
 		call_dissector(frame_dissector, payload_tvb, pinfo, frame_tree);
 	}
@@ -1170,7 +1170,7 @@ display_frame_rx(packet_info* pinfo, sensorlab_frame_info_s* info, gchar* frame_
 
 	frame_dissector =find_dissector(frame_dissector_name);
 	if(frame_dissector && info->payload.frame_info.data_length >0){
-		payload_tvb = tvb_new_subset(tvb, FRAME_RX_DATA_FIELD,  info->payload.frame_info.data_length, -1);
+		payload_tvb = tvb_new_subset_length(tvb, FRAME_RX_DATA_FIELD,  info->payload.frame_info.data_length);
 		frame_tree = proto_item_add_subtree(frame_item, ett_frame);
 		call_dissector(frame_dissector, payload_tvb, pinfo, frame_tree);
 	}
@@ -1213,7 +1213,7 @@ display_frame_consume(packet_info* pinfo, sensorlab_frame_info_s* info, gchar* f
 
 	frame_dissector =find_dissector(frame_dissector_name);
 	if(frame_dissector && info->payload.frame_info.data_length >0){
-		payload_tvb = tvb_new_subset(tvb, FRAME_CONSUME_DATA_FIELD,  info->payload.frame_info.data_length, -1);
+		payload_tvb = tvb_new_subset_length(tvb, FRAME_CONSUME_DATA_FIELD,  info->payload.frame_info.data_length);
 		frame_tree = proto_item_add_subtree(frame_item, ett_frame);
 		call_dissector(frame_dissector, payload_tvb, pinfo, frame_tree);
 	}


### PR DESCRIPTION
straightforward replacement of tvb_new_subset() function calls in packet-sensorlab.c
Replacement of Makefile.am with a file copied/edited from the gryphon example. Not too sure about compatibility with Nmake, etc. Please have a careful look at the diff.